### PR TITLE
Refactor to class - node - action server

### DIFF
--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -5,7 +5,9 @@ find_package(catkin REQUIRED
         COMPONENTS
             roscpp
             tf
+            actionlib
             nav_msgs
+            move_base_msgs
         )
 
 find_package(Boost REQUIRED COMPONENTS system)
@@ -21,15 +23,20 @@ catkin_package(
         include
     LIBRARIES
         image_loader
+        map_generator
     CATKIN_DEPENDS
         roscpp
         tf
         nav_msgs
+        move_base_msgs
+        actionlib
 )
 
 include_directories( include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} )
 add_library(image_loader src/image_loader.cpp)
 target_link_libraries(image_loader SDL SDL_image ${Boost_LIBRARIES})
+
+add_library(map_generator src/map_generator.cpp)
 
 add_executable(map_server src/main.cpp)
 target_link_libraries(map_server
@@ -41,6 +48,7 @@ target_link_libraries(map_server
 add_executable(map_server-map_saver src/map_saver.cpp)
 set_target_properties(map_server-map_saver PROPERTIES OUTPUT_NAME map_saver)
 target_link_libraries(map_server-map_saver
+    map_generator
     ${catkin_LIBRARIES}
     )
 

--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -37,6 +37,9 @@ add_library(image_loader src/image_loader.cpp)
 target_link_libraries(image_loader SDL SDL_image ${Boost_LIBRARIES})
 
 add_library(map_generator src/map_generator.cpp)
+target_link_libraries(map_generator
+    ${catkin_LIBRARIES}
+    )
 
 add_executable(map_server src/main.cpp)
 target_link_libraries(map_server

--- a/map_server/CMakeLists.txt
+++ b/map_server/CMakeLists.txt
@@ -55,6 +55,13 @@ target_link_libraries(map_server-map_saver
     ${catkin_LIBRARIES}
     )
 
+add_executable(map_server-service_based_map_saver src/service_based_map_saver.cpp)
+set_target_properties(map_server-service_based_map_saver PROPERTIES OUTPUT_NAME service_based_map_saver)
+target_link_libraries(map_server-service_based_map_saver
+    map_generator
+    ${catkin_LIBRARIES}
+    )
+
 # copy test data to same place as tests are run
 function(copy_test_data)
     cmake_parse_arguments(PROJECT "" "" "FILES" ${ARGN})

--- a/map_server/README.md
+++ b/map_server/README.md
@@ -1,0 +1,52 @@
+# Usage
+
+## Backward compatible usage
+
+Run a map_saver node that subscribes to the /map topic, saves the map and exits.
+```
+rosrun map_server map_saver -f <map_name>
+```
+
+## Service based usage
+
+Run a service_based_map_saver node that is an action server for map saving.
+The action will subscribe to the /map topic,
+write the available map to a file with the name given in the action goal,
+and unsubscribe from the /map topic.
+```
+rosrun map_server service_based_map_saver
+```
+Call the action, e.g. by publishing to the goal topic:
+```
+rostopic pub /service_based_map_saver/goal move_base_msgs/SaveMapActionGoal "header:
+  seq: 0
+  stamp:
+    secs: 0
+    nsecs: 0
+  frame_id: ''
+goal_id:
+  stamp:
+    secs: 0
+    nsecs: 0
+  id: '1'
+goal:
+  map_name: 'test'"
+```
+Once a map is available, the map will be saved. Trigger by writing a map to the /map topic:
+```
+rostopic pub /map nav_msgs/OccupancyGrid "header:
+ seq: 0
+ stamp:
+   secs: 0
+   nsecs: 0
+ frame_id: ''
+info:
+ map_load_time: {secs: 0, nsecs: 0}
+ resolution: 0.0
+ width: 0
+ height: 0
+ origin:
+   position: {x: 0.0, y: 0.0, z: 0.0}
+   orientation: {x: 0.0, y: 0.0, z: 0.0, w: 0.0}
+data: [0]"
+```

--- a/map_server/package.xml
+++ b/map_server/package.xml
@@ -16,18 +16,22 @@
     <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
     <build_depend>nav_msgs</build_depend>
+    <build_depend>move_base_msgs</build_depend>
     <build_depend>roscpp</build_depend>
     <build_depend>rostest</build_depend>
     <build_depend>sdl-image</build_depend>
     <build_depend>tf</build_depend>
     <build_depend>yaml-cpp</build_depend>
+    <build_depend>actionlib</build_depend>
 
     <run_depend>nav_msgs</run_depend>
+    <run_depend>move_base_msgs</run_depend>
     <run_depend>roscpp</run_depend>
     <run_depend>rostest</run_depend>
     <run_depend>sdl-image</run_depend>
     <run_depend>tf</run_depend>
     <run_depend>yaml-cpp</run_depend>
+    <run_depend>actionlib</run_depend>
 
     <test_depend>rospy</test_depend>
 </package>

--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -220,7 +220,7 @@ class MapServer
     }
 
     bool loadMapService(move_base_msgs::LoadMap::Request  &req,
-             move_base_msgs::LoadMap::Response &res)
+                        move_base_msgs::LoadMap::Response &res)
     {
       bool result;
       try
@@ -264,21 +264,24 @@ class MapServer
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "map_server", ros::init_options::AnonymousName);
-  if(argc > 3)
-  {
-    ROS_ERROR("%s", USAGE);
-    return false;
-  }
-  if (argc != 2 && argc != 1) {
-    ROS_WARN("Using deprecated map server interface. Please switch to new interface.");
-  }
-
   MapServer ms;
+  double res = 0.0;
 
-  if (argc > 1)
+  switch(argc)
   {
+  case 1:
+    // Service based usage: the server is created without loading the map.
+    // The map can be loaded later using the service map_server/load_map.
+    break;
+  case 3:
+    // Deprecated usage: the map is loaded when the server is created using
+    // resolution specification.
+    ROS_WARN("Using deprecated map server interface. Please switch to new interface.");
+    res = atof(argv[2]);
+  case 2:
+  {
+    // Standard usage: the map is loaded when the server is created.
     std::string fname(argv[1]);
-    double res = (argc == 2) ? 0.0 : atof(argv[2]);
     try
     {
       bool result = ms.loadMap(fname, res);
@@ -291,9 +294,13 @@ int main(int argc, char **argv)
       return -1;
     }
   }
+    break;
+  default:
+    ROS_ERROR("%s", USAGE);
+    return false;
+  }
 
   ros::spin();
-
   return 0;
 }
 

--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -238,7 +238,7 @@ bool load_map(move_base_msgs::LoadMap::Request  &req,
   }
 
   res.response = 0;
-  res.message = "map" + req.name + "loaded.";
+  res.message = "map " + req.name + " loaded successfully.";
   return true;
 }
 

--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -253,24 +253,22 @@ int main(int argc, char **argv)
   if (argc != 2 && argc != 1) {
     ROS_WARN("Using deprecated map server interface. Please switch to new interface.");
   }
-  if (argc != 1) {
-    std::string fname(argv[1]);
-    double res = (argc == 2) ? 0.0 : atof(argv[2]);
 
-    try
-    {
-      MapServer ms(fname, res);
-      ros::spin();
-    }
-    catch(std::runtime_error& e)
-    {
-      ROS_ERROR("map_server exception: %s", e.what());
-      return -1;
-    }
-  } else {
-    ros::NodeHandle n;
-    ros::ServiceServer service = n.advertiseService("map_server/load_map", load_map);
+  ros::NodeHandle n;
+  ros::ServiceServer service = n.advertiseService("map_server/load_map", load_map);
+
+  std::string fname(argv[1]);
+  double res = (argc == 2) ? 0.0 : atof(argv[2]);
+
+  try
+  {
+    MapServer ms(fname, res);
     ros::spin();
+  }
+  catch(std::runtime_error& e)
+  {
+    ROS_ERROR("map_server exception: %s", e.what());
+    return -1;
   }
 
 

--- a/map_server/src/main.cpp
+++ b/map_server/src/main.cpp
@@ -61,9 +61,22 @@ class MapServer
 {
   public:
     /** Trivial constructor */
-    MapServer(const std::string& fname, double res)
+    MapServer()
     {
-      std::string mapfname = "";   
+      service = n.advertiseService("static_map", &MapServer::mapCallback, this);
+      load_map_srv_handle = n.advertiseService("map_server/load_map", &MapServer::loadMapService, this);
+
+      // Latched publisher for metadata
+      metadata_pub= n.advertise<nav_msgs::MapMetaData>("map_metadata", 1, true);
+      
+      // Latched publisher for data
+      map_pub = n.advertise<nav_msgs::OccupancyGrid>("map", 1, true);
+    }
+
+    /** Function to load a specific map */
+    bool loadMap(const std::string& fname, double res)
+    {
+      std::string mapfname = "";
       double origin[3];
       int negate;
       double occ_th, free_th;
@@ -78,7 +91,7 @@ class MapServer
         std::ifstream fin(fname.c_str());
         if (fin.fail()) {
           ROS_ERROR("Map_server could not open %s.", fname.c_str());
-          exit(-1);
+          return false;
         }
 #ifdef HAVE_NEW_YAMLCPP
         // The document loading process changed in yaml-cpp 0.5.
@@ -88,31 +101,31 @@ class MapServer
         YAML::Node doc;
         parser.GetNextDocument(doc);
 #endif
-        try { 
-          doc["resolution"] >> res; 
-        } catch (YAML::InvalidScalar) { 
+        try {
+          doc["resolution"] >> res;
+        } catch (YAML::InvalidScalar) {
           ROS_ERROR("The map does not contain a resolution tag or it is invalid.");
-          exit(-1);
+          return false;
         }
-        try { 
-          doc["negate"] >> negate; 
-        } catch (YAML::InvalidScalar) { 
+        try {
+          doc["negate"] >> negate;
+        } catch (YAML::InvalidScalar) {
           ROS_ERROR("The map does not contain a negate tag or it is invalid.");
-          exit(-1);
+          return false;
         }
-        try { 
-          doc["occupied_thresh"] >> occ_th; 
-        } catch (YAML::InvalidScalar) { 
+        try {
+          doc["occupied_thresh"] >> occ_th;
+        } catch (YAML::InvalidScalar) {
           ROS_ERROR("The map does not contain an occupied_thresh tag or it is invalid.");
-          exit(-1);
+          return false;
         }
-        try { 
-          doc["free_thresh"] >> free_th; 
-        } catch (YAML::InvalidScalar) { 
+        try {
+          doc["free_thresh"] >> free_th;
+        } catch (YAML::InvalidScalar) {
           ROS_ERROR("The map does not contain a free_thresh tag or it is invalid.");
-          exit(-1);
+          return false;
         }
-        try { 
+        try {
           std::string modeS = "";
           doc["mode"] >> modeS;
 
@@ -124,27 +137,27 @@ class MapServer
             mode = RAW;
           else{
             ROS_ERROR("Invalid mode tag \"%s\".", modeS.c_str());
-            exit(-1);
+            return false;
           }
-        } catch (YAML::Exception) { 
+        } catch (YAML::Exception) {
           ROS_DEBUG("The map does not contain a mode tag or it is invalid... assuming Trinary");
           mode = TRINARY;
         }
-        try { 
-          doc["origin"][0] >> origin[0]; 
-          doc["origin"][1] >> origin[1]; 
-          doc["origin"][2] >> origin[2]; 
-        } catch (YAML::InvalidScalar) { 
+        try {
+          doc["origin"][0] >> origin[0];
+          doc["origin"][1] >> origin[1];
+          doc["origin"][2] >> origin[2];
+        } catch (YAML::InvalidScalar) {
           ROS_ERROR("The map does not contain an origin tag or it is invalid.");
-          exit(-1);
+          return false;
         }
-        try { 
-          doc["image"] >> mapfname; 
+        try {
+          doc["image"] >> mapfname;
           // TODO: make this path-handling more robust
           if(mapfname.size() == 0)
           {
             ROS_ERROR("The image tag cannot be an empty string.");
-            exit(-1);
+            return false;
           }
           if(mapfname[0] != '/')
           {
@@ -153,9 +166,9 @@ class MapServer
             mapfname = std::string(dirname(fname_copy)) + '/' + mapfname;
             free(fname_copy);
           }
-        } catch (YAML::InvalidScalar) { 
+        } catch (YAML::InvalidScalar) {
           ROS_ERROR("The map does not contain an image tag or it is invalid.");
-          exit(-1);
+          return false;
         }
       } else {
         private_nh.param("negate", negate, 0);
@@ -176,16 +189,13 @@ class MapServer
                map_resp_.map.info.resolution);
       meta_data_message_ = map_resp_.map.info;
 
-      service = n.advertiseService("static_map", &MapServer::mapCallback, this);
-      //pub = n.advertise<nav_msgs::MapMetaData>("map_metadata", 1,
-
-      // Latched publisher for metadata
-      metadata_pub= n.advertise<nav_msgs::MapMetaData>("map_metadata", 1, true);
+      // Publish new map metadata
       metadata_pub.publish( meta_data_message_ );
-      
-      // Latched publisher for data
-      map_pub = n.advertise<nav_msgs::OccupancyGrid>("map", 1, true);
+
+      // Publish new map
       map_pub.publish( map_resp_.map );
+
+      return true;
     }
 
   private:
@@ -193,6 +203,7 @@ class MapServer
     ros::Publisher map_pub;
     ros::Publisher metadata_pub;
     ros::ServiceServer service;
+    ros::ServiceServer load_map_srv_handle;
     bool deprecated;
 
     /** Callback invoked when someone requests our service */
@@ -206,6 +217,34 @@ class MapServer
       ROS_INFO("Sending map");
 
       return true;
+    }
+
+    bool loadMapService(move_base_msgs::LoadMap::Request  &req,
+             move_base_msgs::LoadMap::Response &res)
+    {
+      bool result;
+      try
+      {
+        result = loadMap(req.name, 0.0);
+      }
+      catch(std::runtime_error& e)
+      {
+        ROS_ERROR("map_server exception: %s", e.what());
+        res.response = -1;
+        res.message = "map_server exception: "+ std::string(e.what());
+        return false;
+      }
+
+      if (result)
+      {
+        res.response = 0;
+        res.message = "map " + req.name + " loaded successfully.";
+        return true;
+      }
+
+      res.response = -1;
+      res.message = "Error loading map " + req.name;
+      return false;
     }
 
     /** The map data is cached here, to be sent out to service callers
@@ -222,55 +261,38 @@ class MapServer
 
 };
 
-bool load_map(move_base_msgs::LoadMap::Request  &req,
-         move_base_msgs::LoadMap::Response &res)
-{
-  try
-  {
-    MapServer ms(req.name, 0.0);
-  }
-  catch(std::runtime_error& e)
-  {
-    ROS_ERROR("map_server exception: %s", e.what());
-    res.response = -1;
-    res.message = "map_server exception: "+ std::string(e.what());
-    return false;
-  }
-
-  res.response = 0;
-  res.message = "map " + req.name + " loaded successfully.";
-  return true;
-}
-
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "map_server", ros::init_options::AnonymousName);
-  if(argc != 3 && argc != 2 && argc != 1)
+  if(argc > 3)
   {
     ROS_ERROR("%s", USAGE);
-    exit(-1);
+    return false;
   }
   if (argc != 2 && argc != 1) {
     ROS_WARN("Using deprecated map server interface. Please switch to new interface.");
   }
 
-  ros::NodeHandle n;
-  ros::ServiceServer service = n.advertiseService("map_server/load_map", load_map);
+  MapServer ms;
 
-  std::string fname(argv[1]);
-  double res = (argc == 2) ? 0.0 : atof(argv[2]);
-
-  try
+  if (argc > 1)
   {
-    MapServer ms(fname, res);
-    ros::spin();
-  }
-  catch(std::runtime_error& e)
-  {
-    ROS_ERROR("map_server exception: %s", e.what());
-    return -1;
+    std::string fname(argv[1]);
+    double res = (argc == 2) ? 0.0 : atof(argv[2]);
+    try
+    {
+      bool result = ms.loadMap(fname, res);
+      if (!result)
+        exit(-1);
+    }
+    catch(std::runtime_error& e)
+    {
+      ROS_ERROR("map_server exception: %s", e.what());
+      return -1;
+    }
   }
 
+  ros::spin();
 
   return 0;
 }

--- a/map_server/src/map_generator.cpp
+++ b/map_server/src/map_generator.cpp
@@ -1,0 +1,157 @@
+/*
+ * map_saver
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the <ORGANIZATION> nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cstdio>
+#include "ros/ros.h"
+#include <actionlib/server/simple_action_server.h>
+#include "ros/console.h"
+#include "nav_msgs/GetMap.h"
+#include "tf/LinearMath/Matrix3x3.h"
+#include "geometry_msgs/Quaternion.h"
+#include <map_server/map_generator.h>
+#include <move_base_msgs/SaveMapAction.h>
+
+using namespace std;
+
+MapGenerator::MapGenerator(const std::string& default_map_name,
+                           const std::string& action_name) :
+    mapname_(default_map_name),
+    action_name_(action_name),
+    saved_map_(false),
+    as_(n_, action_name_,
+        boost::bind(&MapGenerator::saveMapActionCallback, this, _1),
+        false)
+{}
+
+MapGenerator::MapGenerator(const std::string& mapname) :
+    mapname_(mapname),
+    saved_map_(false),
+    // TODO(@dvanthienen) How to get rid of this action server instance?
+    as_(n_, "map_saver",
+        boost::bind(&MapGenerator::saveMapActionCallback, this, _1),
+        false)
+{
+  ROS_INFO("Waiting for the map");
+  map_sub_ = n_.subscribe("map", 1, &MapGenerator::mapCallback, this);
+}
+
+void MapGenerator::mapCallback(const nav_msgs::OccupancyGridConstPtr& map)
+{
+  ROS_INFO("Received a %d X %d map @ %.3f m/pix",
+           map->info.width,
+           map->info.height,
+           map->info.resolution);
+
+
+  std::string mapdatafile = mapname_ + ".pgm";
+  ROS_INFO("Writing map occupancy data to %s", mapdatafile.c_str());
+  FILE* out = fopen(mapdatafile.c_str(), "w");
+  if (!out)
+  {
+    ROS_ERROR("Couldn't save map file to %s", mapdatafile.c_str());
+    return;
+  }
+
+  fprintf(out, "P5\n# CREATOR: Map_generator.cpp %.3f m/pix\n%d %d\n255\n",
+          map->info.resolution, map->info.width, map->info.height);
+  for(unsigned int y = 0; y < map->info.height; y++) {
+    for(unsigned int x = 0; x < map->info.width; x++) {
+      unsigned int i = x + (map->info.height - y - 1) * map->info.width;
+      if (map->data[i] == 0) { //occ [0,0.1)
+        fputc(254, out);
+      } else if (map->data[i] == +100) { //occ (0.65,1]
+        fputc(000, out);
+      } else { //occ [0.1,0.65]
+        fputc(205, out);
+      }
+    }
+  }
+
+  fclose(out);
+
+
+  std::string mapmetadatafile = mapname_ + ".yaml";
+  ROS_INFO("Writing map occupancy data to %s", mapmetadatafile.c_str());
+  FILE* yaml = fopen(mapmetadatafile.c_str(), "w");
+
+
+  /*
+resolution: 0.100000
+origin: [0.000000, 0.000000, 0.000000]
+#
+negate: 0
+occupied_thresh: 0.65
+free_thresh: 0.196
+
+   */
+
+  geometry_msgs::Quaternion orientation = map->info.origin.orientation;
+  tf::Matrix3x3 mat(tf::Quaternion(orientation.x, orientation.y, orientation.z, orientation.w));
+  double yaw, pitch, roll;
+  mat.getEulerYPR(yaw, pitch, roll);
+
+  fprintf(yaml, "image: %s\nresolution: %f\norigin: [%f, %f, %f]\nnegate: 0\noccupied_thresh: 0.65\nfree_thresh: 0.196\n\n",
+          mapdatafile.c_str(), map->info.resolution, map->info.origin.position.x, map->info.origin.position.y, yaw);
+
+  fclose(yaml);
+
+  ROS_INFO("Done\n");
+  saved_map_ = true;
+}
+
+void MapGenerator::saveMapActionCallback(
+    const move_base_msgs::SaveMapGoalConstPtr &goal)
+{
+  mapname_ = goal->map_name;
+  move_base_msgs::SaveMapResult result;
+  result.response = -1;
+  // helper variables
+  ros::Rate r(10);
+  bool success = true;
+
+  map_sub_ = n_.subscribe("map", 1, &MapGenerator::mapCallback, this);
+
+  while (!saved_map_) {
+    if (as_.isPreemptRequested() || !ros::ok()) {
+      ROS_INFO("Map generator Preempted");
+      // set the action state to preempted
+      as_.setPreempted();
+      success = false;
+      break;
+    }
+    r.sleep();
+  }
+  if (success) {
+    n_.shutdown();
+    result.response = 0;
+  }
+  as_.setSucceeded(result, "Map saved.");
+  saved_map_ = false;
+}

--- a/map_server/src/map_generator.cpp
+++ b/map_server/src/map_generator.cpp
@@ -48,12 +48,15 @@ MapGenerator::MapGenerator(const std::string& default_map_name,
     as_(n_, action_name_,
         boost::bind(&MapGenerator::saveMapActionCallback, this, _1),
         false)
-{}
+{
+  as_.start();
+}
 
 MapGenerator::MapGenerator(const std::string& mapname) :
     mapname_(mapname),
     saved_map_(false),
     // TODO(@dvanthienen) How to get rid of this action server instance?
+    // Since the action server is not started, it can not be abused.
     as_(n_, "map_saver",
         boost::bind(&MapGenerator::saveMapActionCallback, this, _1),
         false)

--- a/map_server/src/service_based_map_saver.cpp
+++ b/map_server/src/service_based_map_saver.cpp
@@ -1,6 +1,6 @@
 /*
- * map_saver
- * Copyright (c) 2008, Willow Garage, Inc.
+ * service_based_map_saver
+ * Copyright (c) 2017, Intermodalics, bvba
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
+ * Author: Dominick Vanthienen
+ */
+
 #include <cstdio>
 #include "ros/ros.h"
 #include "ros/console.h"
@@ -38,48 +42,13 @@
 
 using namespace std;
 
-#define USAGE "Usage: \n" \
-              "  map_saver -h\n"\
-              "  map_saver [-f <mapname>] [ROS remapping args]"
-
 int main(int argc, char** argv)
 {
-  ros::init(argc, argv, "map_saver");
-  std::string mapname = "map";
+  ros::init(argc, argv, "service_based_map_saver");
 
-  for(int i=1; i<argc; i++)
-  {
-    if(!strcmp(argv[i], "-h"))
-    {
-      puts(USAGE);
-      return 0;
-    }
-    else if(!strcmp(argv[i], "-f"))
-    {
-      if(++i < argc)
-        mapname = argv[i];
-      else
-      {
-        puts(USAGE);
-        return 1;
-      }
-    }
-    else
-    {
-      puts(USAGE);
-      return 1;
-    }
-  }
+  MapGenerator mg("default_map", "service_based_map_saver");
 
-  if(*mapname.rbegin() == '/')
-    mapname += "map";
-
-  MapGenerator mg(mapname);
-
-  while(!mg.saved_map() && ros::ok())
-    ros::spinOnce();
+  ros::spin();
 
   return 0;
 }
-
-

--- a/move_base_msgs/CMakeLists.txt
+++ b/move_base_msgs/CMakeLists.txt
@@ -8,12 +8,12 @@ find_package(catkin REQUIRED
         geometry_msgs
         )
 
-
 # actions
 add_action_files(
     DIRECTORY action
     FILES
         MoveBase.action
+        SaveMap.action
 )
 
 generate_messages(

--- a/move_base_msgs/CMakeLists.txt
+++ b/move_base_msgs/CMakeLists.txt
@@ -16,6 +16,11 @@ add_action_files(
         SaveMap.action
 )
 
+add_service_files(
+  FILES
+  LoadMap.srv
+)
+
 generate_messages(
     DEPENDENCIES
         actionlib_msgs

--- a/move_base_msgs/action/SaveMap.action
+++ b/move_base_msgs/action/SaveMap.action
@@ -1,0 +1,4 @@
+string map_name
+---
+int8 response
+---

--- a/move_base_msgs/package.xml
+++ b/move_base_msgs/package.xml
@@ -18,6 +18,7 @@
     <build_depend>actionlib_msgs</build_depend>
     <build_depend>geometry_msgs</build_depend>
     <build_depend>message_generation</build_depend>
+    <build_depend>std_srvs</build_depend>
 
     <run_depend>actionlib_msgs</run_depend>
     <run_depend>geometry_msgs</run_depend>

--- a/move_base_msgs/srv/LoadMap.srv
+++ b/move_base_msgs/srv/LoadMap.srv
@@ -1,0 +1,4 @@
+string name
+---
+int8 response
+string message


### PR DESCRIPTION
The map_saver can now be launched as a long running action server, allowing an action with map name to be called on it.
The map_server package can now be launched without any map.
The user can load the desired map on the fly using the service map_server/load_map.
TODO

- [ ] rename service_based_map_saver to map_saver_action_server
- [ ]  cleanup to code standards